### PR TITLE
Opps config file & automation 

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -14,7 +15,8 @@ import { OppsPageComponent } from './opps-page/opps-page.component';
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    HttpClientModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/league-of-legends.service.spec.ts
+++ b/src/app/league-of-legends.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LeagueOfLegendsService } from './league-of-legends.service';
+
+describe('LeagueOfLegendsService', () => {
+  let service: LeagueOfLegendsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LeagueOfLegendsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/league-of-legends.service.ts
+++ b/src/app/league-of-legends.service.ts
@@ -2,22 +2,57 @@ import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, tap } from 'rxjs';
 
-
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class LeagueOfLegendsService {
-  private apiUrl = "https://esports-api.lolesports.com/persisted/gw/getStandings?hl=fr-FR&tournamentId=112445505684034122";
-  private key = "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z";
-  private tournamentKey = "112445505684034122";
+  private apiUrl =
+    'https://esports-api.lolesports.com/persisted/gw/getStandings?hl=fr-FR&tournamentId=112445505684034122';
+  private key = '0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z';
+  private tournamentKey = '112445505684034122';
   private lang = 'fr-FR';
+  private matches: any[] = [];
 
   constructor(private http: HttpClient) {}
 
-  getMatches(): Observable<any> {
+  getAllMatches(): Observable<any> {
     const headers = new HttpHeaders({ 'x-api-key': this.key });
-    let httpParams = new HttpParams().set('hl', this.lang).set('tournamentId', this.tournamentKey);
-    
+    let httpParams = new HttpParams()
+      .set('hl', this.lang)
+      .set('tournamentId', this.tournamentKey);
+
     return this.http.get(this.apiUrl, { headers });
+  }
+
+  getMatches(): Observable<any[]> {
+    return new Observable((observer) => {
+      this.getAllMatches().subscribe({
+        next: (data) => {
+          const extractedMatches = this.extractMatchesKC(data);
+          observer.next(extractedMatches);
+          observer.complete();
+        },
+        error: (err) => observer.error(err),
+      });
+    });
+  }
+
+  extractMatchesKC(data: any): any[] {
+    const matches: any[] = [];
+    data.data.standings.forEach((standing: any) => {
+      standing.stages.forEach((stage: any) => {
+        stage.sections.forEach((section: any) => {
+          section.matches.forEach((match: any) => {
+            if (match.teams.length === 2) {
+              const teamCodes = match.teams.map((team: any) => team.code);
+              if (teamCodes.includes('KCB') || teamCodes.includes('KC')) {
+                matches.push(match);
+              }
+            }
+          });
+        });
+      });
+    });
+    return matches;
   }
 }

--- a/src/app/league-of-legends.service.ts
+++ b/src/app/league-of-legends.service.ts
@@ -1,0 +1,23 @@
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, tap } from 'rxjs';
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LeagueOfLegendsService {
+  private apiUrl = "https://esports-api.lolesports.com/persisted/gw/getStandings?hl=fr-FR&tournamentId=112445505684034122";
+  private key = "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z";
+  private tournamentKey = "112445505684034122";
+  private lang = 'fr-FR';
+
+  constructor(private http: HttpClient) {}
+
+  getMatches(): Observable<any> {
+    const headers = new HttpHeaders({ 'x-api-key': this.key });
+    let httpParams = new HttpParams().set('hl', this.lang).set('tournamentId', this.tournamentKey);
+    
+    return this.http.get(this.apiUrl, { headers });
+  }
+}

--- a/src/app/opps-page/opps-page.component.html
+++ b/src/app/opps-page/opps-page.component.html
@@ -2,7 +2,22 @@
 <div *ngFor="let team of opps | keyvalue">
 <ng-container *ngIf="team.key === oppsName">
     <ul>
-    <li *ngFor="let game of team.value">{{ game }}</li>
+    <li *ngFor="let game of team.value.games">{{ game }}</li>
     </ul>
 </ng-container>
 </div>
+
+
+<!-- Affichage des matchs-->
+<ul>
+<li *ngFor="let match of matches">
+    <div class="matchInfo">
+    Match ID: {{ match.id }} 
+
+    </div>
+</li>
+</ul>
+
+
+
+

--- a/src/app/opps-page/opps-page.component.ts
+++ b/src/app/opps-page/opps-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { oppsConfig } from '../../config/opps.config'
+import { LeagueOfLegendsService } from '../league-of-legends.service';
 
 
 @Component({
@@ -11,14 +12,65 @@ import { oppsConfig } from '../../config/opps.config'
 export class OppsPageComponent implements OnInit {
   oppsName: string | undefined;
   opps = oppsConfig
+  opp: any = {};
+  matches: any[] = [];
+  teams: any[] = [];
 
   constructor(
-    private readonly route: ActivatedRoute) {}
+    private readonly route: ActivatedRoute,
+    private lolMatchService: LeagueOfLegendsService) {}
 
   ngOnInit(): void {
       this.route.paramMap.subscribe(params => {
       this.oppsName = params.get('oppsName') ?? 'Not an opp';
+      this.getStandings();
+      this.getOppDetails();
   });
   }
+
+  /**
+   * Définit Opp comme l'objet de configuration sachant le nom
+   */
+  getOppDetails(): void {
+    if (this.oppsName && this.opps[this.oppsName]) {
+      this.opp = this.opps[this.oppsName];
+    } else {
+      this.opp = { aliases: ['Non trouvé'], games: [] };
+    }
+  }
+
+
+  getStandings(): void {
+    this.lolMatchService.getMatches().subscribe({
+      next: (data) => {
+        this.extractTeams(data);
+      },
+      error: (err) => console.error('Erreur lors de la récupération des standings:', err)
+    });
+  }
+
+extractTeams(data: any): any[] {
+    data.data.standings.forEach((standing: any) => {
+        standing.stages.forEach((stage: any) => {
+            stage.sections.forEach((section: any) => {
+                section.matches.forEach((match: any) => {
+                   if (match.teams.length === 2) {
+                        const teamCodes = match.teams.map((team: any) => team.code);
+                        if ((teamCodes.includes("KCB") || teamCodes.includes("KC")) 
+                        && this.opp.aliases.some((alias: string) => teamCodes.includes(alias))) {
+                            this.matches.push(match);
+                        }
+                    } 
+                });
+            });
+        });
+    });
+    return this.matches;
+}
+
+
+
+
+
 
 }

--- a/src/app/opps-page/opps-page.component.ts
+++ b/src/app/opps-page/opps-page.component.ts
@@ -1,32 +1,35 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { oppsConfig } from '../../config/opps.config'
+import { oppsConfig } from '../../config/opps.config';
 import { LeagueOfLegendsService } from '../league-of-legends.service';
-
 
 @Component({
   selector: 'app-opps-page',
   templateUrl: './opps-page.component.html',
-  styleUrls: ['./opps-page.component.css']
+  styleUrls: ['./opps-page.component.css'],
 })
 export class OppsPageComponent implements OnInit {
   oppsName: string | undefined;
-  opps = oppsConfig
+  opps = oppsConfig;
   opp: any = {};
   matches: any[] = [];
   teams: any[] = [];
 
   constructor(
     private readonly route: ActivatedRoute,
-    private lolMatchService: LeagueOfLegendsService) {}
+    private readonly lolMatchService: LeagueOfLegendsService
+  ) {}
 
   ngOnInit(): void {
-      this.route.paramMap.subscribe(params => {
-      this.oppsName = params.get('oppsName') ?? 'Not an opp';
-      this.getStandings();
-      this.getOppDetails();
+  this.route.paramMap.subscribe((params) => {
+    this.oppsName = params.get('oppsName') ?? 'Not an opp';
+    this.getOppDetails();
+
+    this.lolMatchService.getMatches().subscribe((data) => {
+      this.extractTeams(data);
+    });
   });
-  }
+}
 
   /**
    * Définit Opp comme l'objet de configuration sachant le nom
@@ -39,38 +42,14 @@ export class OppsPageComponent implements OnInit {
     }
   }
 
-
-  getStandings(): void {
-    this.lolMatchService.getMatches().subscribe({
-      next: (data) => {
-        this.extractTeams(data);
-      },
-      error: (err) => console.error('Erreur lors de la récupération des standings:', err)
+  extractTeams(matches: any[]): void {
+    matches.forEach((match: any) => {
+      if (match.teams.length === 2) {
+        const teamCodes = match.teams.map((team: any) => team.code);
+        if (this.opp.aliases.some((alias: string) => teamCodes.includes(alias))) {
+          this.matches.push(match);
+        }
+      }
     });
   }
-
-extractTeams(data: any): any[] {
-    data.data.standings.forEach((standing: any) => {
-        standing.stages.forEach((stage: any) => {
-            stage.sections.forEach((section: any) => {
-                section.matches.forEach((match: any) => {
-                   if (match.teams.length === 2) {
-                        const teamCodes = match.teams.map((team: any) => team.code);
-                        if ((teamCodes.includes("KCB") || teamCodes.includes("KC")) 
-                        && this.opp.aliases.some((alias: string) => teamCodes.includes(alias))) {
-                            this.matches.push(match);
-                        }
-                    } 
-                });
-            });
-        });
-    });
-    return this.matches;
-}
-
-
-
-
-
-
 }

--- a/src/config/opps.config.ts
+++ b/src/config/opps.config.ts
@@ -1,5 +1,23 @@
-export const oppsConfig = {
-  'GentleMates': ['Rocket League', 'Valorant (VCT)', 'League of Legends (LFL)'],
-  'Solary': ['League of Legends (LFL)'],
-  'Vitality': ['Rocket League', 'Valorant (VCT)', 'League of Legends (LEC)', 'League of Legends (LFL)'],
+type TeamConfig = {
+  aliases: string[];
+  games: string[];
+};
+
+type OppsConfig = {
+  [key: string]: TeamConfig; // Utilisation d'une signature d'indexation pour permettre d'accéder à une équipe par son nom
+};
+
+export const oppsConfig: OppsConfig = {
+  'GentleMates': {
+    aliases: ['GentleMates', 'M8'],
+    games: ['Rocket League', 'Valorant (VCT)', 'League of Legends (LFL)']
+  },
+  'Solary': {
+    aliases: ['Solary', 'SLY'],
+    games: ['League of Legends (LFL)']
+  },
+  'Vitality': {
+    aliases: ['Vitality', 'VIT', 'VITB'],
+    games: ['Rocket League', 'Valorant (VCT)', 'League of Legends (LEC)', 'League of Legends (LFL)']
+  }
 };

--- a/src/config/tournamentsLoL.config.ts
+++ b/src/config/tournamentsLoL.config.ts
@@ -1,0 +1,35 @@
+const tournamentLoLConfig = {
+  LFL2: {},
+  LFL: {
+    'lfl_ko_2025': { id: '113662954820773942', name: 'LFL Knockout 2025' },
+    'lfl_summer_2024': { id: '112445505684034122', name: 'LFL Summer 2024' },
+    'lfl_spring_2024': { id: '111561126754061496', name: 'LFL Spring 2024' },
+    'lfl_summer_2023': { id: '110424922266960422', name: 'LFL Summer 2023' },
+    'lfl_spring_2023': { id: '109467129925344897', name: 'LFL Spring 2023' },
+    'lfl_2022_summer': { id: '108158179538212767', name: 'LFL Summer 2022' },
+    'lfl_2022_spring': { id: '107468370558963709', name: 'LFL Spring 2022' },
+    'lfl_2021_summer': { id: '106313258182079617', name: 'LFL Summer 2021' },
+    'lfl_2021_spring': { id: '105568157420311272', name: 'LFL Spring 2021' },
+  },
+  'EMEA Masters': {
+    'emea_masters_winter_2025': { id: '113990292491935482', name: 'EMEA Masters Winter 2025' },
+    'emea_masters_summer_2024': { id: '112800626303511505', name: 'EMEA Masters Summer 2024' },
+    'emea_masters_spring_2024': { id: '112009683822726475', name: 'EMEA Masters Spring 2024' },
+    'emea_masters_summer_2023': { id: '110535609415063567', name: 'EMEA Masters Summer 2023' },
+    'european_masters_spring_2022_main_event': { id: '107893386210553711', name: 'European Masters Spring 2022 Main Event' },
+    'european_masters_spring_2022_play_ins': { id: '107893136888836553', name: 'European Masters Spring 2022 Play-Ins' },
+    'european_masters_summer_2021_main_event': { id: '106748850929174796', name: 'European Masters Summer 2021 Main Event' },
+    'european_masters_spring_2021_main_event': { id: '105990084003609117', name: 'European Masters Spring 2021 Main Event' },
+  },
+  LEC: {
+    'lec_summer_2025': { id: '113487526512660769', name: 'LEC Summer 2025' },
+    'lec_spring_2025': { id: '113487400974323999', name: 'LEC Spring 2025' },
+    'lec_winter_2025': { id: '113475994398658012', name: 'LEC Winter 2025' },
+    'lec_summer_2024': { id: '112352881163915249', name: 'LEC Summer 2024' },
+    'lec_spring_2024': { id: '111997906550466231', name: 'LEC Spring 2024' },
+    'lec_winter_2024': { id: '111560983131400452', name: 'LEC Winter 2024' },
+  },
+  Internationals: {
+    'first_stand' : { id: '113464388705111224', name: 'First Stand' }
+  }
+};


### PR DESCRIPTION
**Fichiers de configuration :** 
Opps : 
- Implique directement la navigation et le front des pages individuelles.
- Algorithmes de récupération des matchs accordés sur ce même fichier.
TounamentLoL : 
- Liste exhaustive des tournois (slug_name, id, nom)

RAF :
- Parcours du fichier des tournois et récupération de toutes les parties (à trier par date, à voir pour les logos des compétitions)
- Front à fond
- Tournois/API autres jeux